### PR TITLE
Made compatible with Tensorflow 2.0+

### DIFF
--- a/gain.py
+++ b/gain.py
@@ -7,7 +7,11 @@ Contact: jsyoon0823@gmail.com
 '''
 
 # Necessary packages
-import tensorflow as tf
+#import tensorflow as tf
+##IF USING TF 2 use following import to still use TF < 2.0 Functionalities
+import tensorflow.compat.v1 as tf
+tf.disable_v2_behavior()
+
 import numpy as np
 from tqdm import tqdm
 

--- a/utils.py
+++ b/utils.py
@@ -12,7 +12,10 @@
  
 # Necessary packages
 import numpy as np
-import tensorflow as tf
+#import tensorflow as tf
+##IF USING TF 2 use following import to still use TF < 2.0 Functionalities
+import tensorflow.compat.v1 as tf
+tf.disable_v2_behavior()
 
 
 def normalization (data, parameters=None):


### PR DESCRIPTION
If you are using TF 2.0+, it will give error of TensorFlow, “'module' object has no attribute 'placeholder'”.
Therefore to make TF2.0+ version compatible with older version modified import in gain.py and utils.py